### PR TITLE
Adding a bower.json for bower publishing

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
    "name": "pure-templates",
    "version": "2.82.0",
-   "main": "libs/pure.min.js"
+   "main": "libs/pure.js"
 }


### PR DESCRIPTION
Hey Team,
In order to support bower package management (http://bower.io/), I've added a bower.json manifest file.  However, to fully support this, you'll need to add semver (http://semver.org/) tags to your repo.  This isn't scary, it should just match the versioning you're using. 

You'll also need to register pure with the bower registry via 'bower register', but this is predicated on the manifest file and the semver tags.  

In order to maintain the bower package, you'll need to update 'bower.json' according to the semver rules, and create git tags as your'e ready for release.

Cheers!
Chris
