### PR TITLE
Enable use with XHTML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ commit.sh
 js/*.html
 bugs/*
 compiler.jar
-/nbproject/private/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ commit.sh
 js/*.html
 bugs/*
 compiler.jar
+/nbproject/private/

--- a/libs/pure.js
+++ b/libs/pure.js
@@ -686,8 +686,13 @@ $p.core = function(sel, ctxt, plugins){
 			break;
 		}
 		tmp = document.createElement('SPAN');
-		tmp.style.display = 'none';
-		document.body.appendChild(tmp);
+		if( tmp.style ) { // Ignore if not present, since in XML Document we don't have tmp.style
+            tmp.style.display = 'none';
+        }
+        var body= document.body!==undefined
+            ? document.body
+            : document.getElementsByTagNameNS( "http://www.w3.org/1999/xhtml", 'body')[0];
+		body.appendChild(tmp);
 		tmp.innerHTML = html;
 		ne = tmp.firstChild;
 		while (depth--) {
@@ -695,7 +700,7 @@ $p.core = function(sel, ctxt, plugins){
 		}
 		ep.insertBefore(ne, elm);
 		ep.removeChild(elm);
-		document.body.removeChild(tmp);
+		body.removeChild(tmp);
 		elm = ne;
 
 		ne = ep = null;


### PR DESCRIPTION
Hi Michael,

Thank you for PURE.

There's even more use for it: with XML templates, too. Real-world use case is to generate templated XML (as an export) from a Firefox add-on (https://github.com/SeLite/SeLite/tree/master/preview/src/chrome/content - work in progress).

See an example at https://github.com/peter-kehl/LinkedIn/blob/master/simple.xml. See it in action at https://rawgit.com/peter-kehl/LinkedIn/master/simple.xml.